### PR TITLE
## kubernetes-debug

### DIFF
--- a/kubernetes-debug/kit/cr-nodes.yaml
+++ b/kubernetes-debug/kit/cr-nodes.yaml
@@ -1,0 +1,7 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"
+spec:
+  serverNode: "minikube"
+  clientNode: "minikube"

--- a/kubernetes-debug/kit/cr.yaml
+++ b/kubernetes-debug/kit/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/crd.yaml
+++ b/kubernetes-debug/kit/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: "apps/v1"
+kind: "DaemonSet"
+metadata:
+  name: "kube-iptables-tailer"
+  namespace: "kube-system"
+spec:
+  selector:
+    matchLabels:
+      app: kube-iptables-tailer
+  template:
+    metadata:
+      labels:
+        app: "kube-iptables-tailer"
+    spec:
+      serviceAccountName: kube-iptables-tailer
+      containers:
+        - name: "kube-iptables-tailer"
+          command:
+            - "/kube-iptables-tailer"
+            - "--log_dir=/my-service-logs" # change the output directory of service logs
+            - "--v=4" # enable V-leveled logging at this level
+          env:
+            - name: "JOURNAL_DIRECTORY"
+              value: "/var/log/journal"
+            - name: "POD_IDENTIFIER"
+              value: "label"
+            - name: "POD_IDENTIFIER_LABEL"
+              value: "netperf-type"
+            - name: "IPTABLES_LOG_PREFIX"
+              # log prefix defined in your iptables chains
+              value: "calico-packet:"
+          image: "virtualshuric/kube-iptables-tailer:8d4296a"
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: "iptables-logs"
+              mountPath: "/var/log/"
+              readOnly: true
+            - name: "service-logs"
+              mountPath: "/my-service-logs"
+
+      volumes:
+        - name: "iptables-logs"
+          hostPath:
+            # absolute path of the directory containing iptables log file on your host
+            path: "/var/log"
+        - name: "service-logs"
+          emptyDir: {}
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-iptables-tailer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["v1"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "get", "watch", "list", "create", "delete", "patch", "update" ]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-iptables-tailer
+subjects:
+  - kind: ServiceAccount
+    name: kube-iptables-tailer
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kube-iptables-tailer
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/netperf-calico-policy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/kit/operator.yaml
+++ b/kubernetes-debug/kit/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/rbac.yaml
+++ b/kubernetes-debug/kit/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/strace/agent_daemonset.yml
+++ b/kubernetes-debug/strace/agent_daemonset.yml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+        - image: aylei/debug-agent:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10027
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: debug-agent
+          ports:
+            - containerPort: 10027
+              hostPort: 10027
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: docker
+              mountPath: "/var/run/docker.sock"
+          securityContext:
+            capabilities:
+              add: [ "SYS_PTRACE" ]
+      hostNetwork: true
+      volumes:
+        - name: docker
+          hostPath:
+            path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate


### PR DESCRIPTION
- kubectl debug не нужно устанавливать с варсии 1.20, но это уже другой дебаг
- установил DaemonSet из agent_daemonset.yml c image: aylei/debug-agent:0.0.1
- убедился что strace -c -p1 выдает "trace: attach: ptrace(PTRACE_SEIZE, 1): Operation not permitted"
- пробовал менять image на latest и запускать с ключем "--agentless=false", но k8s-ый дебаг такое не умеет
- добавлял в манифест пода
```yaml
securityContext:
  capabilities:
    add: [ "SYS_PTRACE" ]
```
 но так и не смог побороть 'ptrace(PTRACE_SEIZE, 1): Operation not permitted'
 - итак теоретически я знаю как победить ошибку, но практически не могу в gcp создать кластер с версией ниже 1.21
- установил netperf-operator
- протестировал скорость с помощью cr.yaml
- применил Calico NetworkPolicy которая блокирует поды Netperf и убедился, что тест не выполняется
- устанавливаем iptables-tailer (а также ClusterRole, ServiceAccount и ClusterRoleBinding для него)
- IPTABLES_LOG_PREFIX переменную выставляем в "calico-packet:"
- задаем JOURNAL_DIRECTORY - "/var/log/journal"
- меняем image тэг на virtualshuric/kube-iptables-tailer:8d4296a
- смотрим event-ы netperf-operator пода и видим "Warning PacketDrop"

# Выполнено ДЗ №

- [x] Основное ДЗ
- [ ] Задание со *

## В процессе сделано:
- Пункт 1
- Пункт 2

## Как запустить проект:
- Например, запустить команду X в директории Y

## Как проверить работоспособность:
- Например, перейти по ссылке http://localhost:8080

## PR checklist:
- [x] Выставлен label с темой домашнего задания